### PR TITLE
Fix fatal bug

### DIFF
--- a/NPCs/BetterTaxesGlobalNPC.cs
+++ b/NPCs/BetterTaxesGlobalNPC.cs
@@ -45,7 +45,7 @@ namespace BetterTaxes.NPCs
                     bool hasChosenDialog = false;
                     while (!hasChosenDialog)
                     {
-                        int chosenDialog = Main.rand.Next(9); // 0 - 8
+                        int chosenDialog = Main.rand.Next(9 + 1); // 0 - 9; one higher than max to avoid inf. loop
                         switch(chosenDialog)
                         {
                             case 0:

--- a/NPCs/BetterTaxesGlobalNPC.cs
+++ b/NPCs/BetterTaxesGlobalNPC.cs
@@ -17,13 +17,13 @@ namespace BetterTaxes.NPCs
 
         internal static bool CheckIfModExists(string name)
         {
-            return ModLoader.GetMod(name) != null;
+            return ModLoader.TryGetMod(name, out _);
         }
     }
 
     public class BetterTaxesGlobalNPC : GlobalNPC
     {
-        public override bool IsLoadingEnabled(Mod mod) => false;
+        public override bool IsLoadingEnabled(Mod mod) => true;
 
         public override void GetChat(NPC npc, ref string chat)
         {
@@ -103,13 +103,11 @@ namespace BetterTaxes.NPCs
                                 }
                                 break;
                             default:
-                                chat = Language.GetTextValue("tModLoader.DefaultTownNPCChat"); hasChosenDialog = true;
+                                hasChosenDialog = true;
                                 break;
                         }
-
                     }
                 }
-
             }
         }
     }

--- a/TaxPlayer.cs
+++ b/TaxPlayer.cs
@@ -6,8 +6,11 @@ namespace BetterTaxes
 {
     public class TaxPlayer : ModPlayer
     {
-        public override bool IsLoadingEnabled(Mod mod) => false;
-
+        public override bool IsLoadingEnabled(Mod mod)
+        {
+            On.Terraria.Player.CollectTaxes += HookAdjustTaxes;
+            return base.IsLoadingEnabled(mod);
+        }
         private void HookAdjustTaxes(On.Terraria.Player.orig_CollectTaxes orig, Player self)
         {
             int cap = TaxWorld.serverConfig.MoneyCap;


### PR DESCRIPTION
I was unable to verify that auto collection or tax rate changes worked at all when I tested this mod by installing it off the workshop, but I was able to get the mod to work by re-enabling the hook to the main game's CollectTaxes method that was disabled at some point and re-enabling autoloading of the global NPC. Without this hook, the mod does not (nor should) work at all.

Since I have not done any Terraria modding for a few years, it is possible that this is not the best way to fix this problem in modern versions of tModLoader; please take my changes with a grain of salt.